### PR TITLE
Add support for alerting the user of new updates.

### DIFF
--- a/app/background.js
+++ b/app/background.js
@@ -3,7 +3,7 @@
 // It doesn't have any windows which you can see on screen, but we can open
 // window from here.
 
-import { app, Menu, ipcMain } from 'electron'
+import { app, Menu, ipcMain, dialog, shell } from 'electron'
 import globalShortcut from 'global-shortcut'
 import path from 'path'
 
@@ -12,6 +12,7 @@ import { editMenuTemplate } from './helpers/edit_menu_template'
 import { windowHelper } from './helpers/window'
 import env from './env'
 import configuration from './configuration'
+import Update from './lib/update'
 
 var setApplicationMenu = function () {
   var menus = [editMenuTemplate]
@@ -24,7 +25,7 @@ var setApplicationMenu = function () {
 app.on('ready', function () {
   setApplicationMenu()
 
-  var mainWindow = windowHelper({
+  let mainWindow = windowHelper({
     width: 600,
     height: 400,
     maxHeight: 400,
@@ -37,6 +38,24 @@ app.on('ready', function () {
     alwaysOnTop: true,
     fullscreenable: false,
     title: 'Zazu',
+  })
+
+  const update = new Update()
+  update.needsUpdate().then((newerVersion) => {
+    if (!newerVersion) { return }
+    dialog.showMessageBox({
+      type: 'question',
+      buttons: ['Ignore', 'Download'],
+      defaultId: 1,
+      cancelId: 0,
+      title: 'Newer version available!',
+      message: `Zazu ${newerVersion} is available for download!`,
+      detail: 'Click download to get the newest version of Zazu!',
+    }, (response) => {
+      if (response === 1) {
+        shell.openExternal('http://zazuapp.org/')
+      }
+    })
   })
 
   // mainWindow.webContents.toggleDevTools();

--- a/app/lib/update.js
+++ b/app/lib/update.js
@@ -1,0 +1,43 @@
+import semver from 'semver'
+import https from 'https'
+import { app } from 'electron'
+
+export default class Update {
+
+  constructor () {
+    this._latestVersion = null
+  }
+
+  needsUpdate () {
+    return this.latestVersion().then((newestVersion) => {
+      return semver.satisfies(newestVersion, `>${app.getVersion()}`) && newestVersion
+    })
+  }
+
+  latestVersion () {
+    return new Promise((resolve, reject) => {
+      if (this._latestVersion) {
+        return resolve(this._latestVersion)
+      }
+      https.get({
+        host: 'api.github.com',
+        path: '/repos/tinytacoteam/zazu/releases/latest',
+        headers: {
+          'User-Agent': `ZazuApp Updater v${app.getVersion()}`,
+        },
+      }, (res) => {
+        var chunks = []
+        res.on('data', (chunk) => {
+          chunks.push(chunk.toString())
+        })
+        res.on('end', () => {
+          this._latestVersion = JSON.parse(chunks.join()).tag_name
+          resolve(this._latestVersion)
+        })
+      }).on('error', (e) => {
+        reject(`Got error: ${e.message}`)
+      })
+    })
+  }
+
+}

--- a/app/package.json
+++ b/app/package.json
@@ -13,7 +13,8 @@
     "mousetrap": "^1.5.3",
     "node-notifier": "^4.5.0",
     "react": "^15.0.1",
-    "react-dom": "^15.0.1"
+    "react-dom": "^15.0.1",
+    "semver": "^5.0.3"
   },
   "packageNameTemplate": "{{name}}-v{{version}}-{{platform}}-{{arch}}",
   "osx": {


### PR DESCRIPTION
On startup, this will check github for the latest release version of
ZazuApp, if the latest release is newer a dialog will appear telling the
user to download the new package. Currently this just opens zazuapp.org.
