### PR TITLE
Add path info to exec on osx release builds.

### DIFF
--- a/app/lib/process.js
+++ b/app/lib/process.js
@@ -1,5 +1,5 @@
 const Promise = require('bluebird')
-const { exec } = require('child_process')
+const { exec, execFile } = require('child_process')
 
 Promise.config({
   cancellation: true,
@@ -25,6 +25,12 @@ class Process {
       })
     })
   }
+}
+
+if (process.platform === 'darwin') {
+  execFile(process.env.SHELL, ['-i', '-c', 'echo $PATH'], (err, stream) => {
+    process.env.PATH = stream.toString().trim()
+  })
 }
 
 module.exports = Process


### PR DESCRIPTION
This adds the `path` info to our `process.env` to ensure `node somescript.js` calls work correctly when zazu is ran from a package on osx.
