### PR TITLE
Remove Zazu from taskbar

### DIFF
--- a/app/background.js
+++ b/app/background.js
@@ -85,6 +85,7 @@ app.on('ready', function () {
     minimizable: false,
     maximizable: false,
     alwaysOnTop: true,
+    skipTaskbar: true,
     fullscreenable: false,
     title: 'Zazu',
     autoResize: true,


### PR DESCRIPTION
Seems like It makes no sense to add Zazu to the taskbar because if you switch to a different application it'll get closed automatically. I found it a bit annoying, so I thought it might be a good idea to remove it.

WDYT?