### PR TITLE
Fix focus when window show

### DIFF
--- a/app/background.js
+++ b/app/background.js
@@ -119,6 +119,7 @@ app.on('ready', function () {
   globalEmitter.on('showWindow', () => {
     logger.log('info', 'showing window from manual trigger')
     mainWindow.show()
+    mainWindow.focus()
   })
 
   globalEmitter.on('toggleWindow', () => {


### PR DESCRIPTION
In the docs says that when call show the window will appears with focus, but it was not happening it here in linux, by calling focus it does it.