### PR TITLE
'onMouse' option to open Zazu below mouse pointer

### DIFF
--- a/app/background.js
+++ b/app/background.js
@@ -1,3 +1,4 @@
+const electron = require('electron')
 const { dialog, app, globalShortcut } = require('electron')
 const path = require('path')
 
@@ -118,6 +119,10 @@ app.on('ready', function () {
 
   globalEmitter.on('showWindow', () => {
     logger.log('info', 'showing window from manual trigger')
+    if (configuration.onMouse) {
+      let {x, y} = electron.screen.getCursorScreenPoint()
+      mainWindow.setPosition(x, y)
+    }
     mainWindow.show()
     mainWindow.focus()
   })

--- a/app/lib/configuration.js
+++ b/app/lib/configuration.js
@@ -32,6 +32,7 @@ class Configuration {
       this.disableAnalytics = data.disableAnalytics
       this.debug = data.debug
       this.loaded = true
+      this.onMouse = data.onMouse
     } catch (e) {
       const logger = require('./logger')
       logger.log('error', 'Attempted to load an invalid ~/.zazurc.json file', {

--- a/docs/_documentation/configuration.md
+++ b/docs/_documentation/configuration.md
@@ -17,6 +17,7 @@ basic usage.
 {
   "hotkey": "alt+space",
   "theme": "tinytacoteam/dark-theme",
+  "onMouse": true,
   "plugins": []
 }
 ~~~~
@@ -35,6 +36,12 @@ would translate to `https://github.com/tinytacoteam/dark-theme`.
 
 There are a [few themes](/themes) we created that you can pick from, feel free
 to fork them and make your own.
+
+### OnMouse
+
+This should be set to true to enable this option.
+
+With this enabled, Zazu will open below the mouse pointer.
 
 ### Plugins
 


### PR DESCRIPTION
https://github.com/tinytacoteam/zazu/issues/124. 

Setting 'onMouse' to true in `.zazurc.json` will cause Zazu to open below the mouse pointer when toggled

```
{
  "hotkey": "alt+shift+space",
  "theme": "tinytacoteam/zazu-light-theme",
  "onMouse": true,
  "plugins": []
}
```