### PR TITLE
Allow prefix to be more versatile.

### DIFF
--- a/app/blocks/input/prefixScript.js
+++ b/app/blocks/input/prefixScript.js
@@ -33,16 +33,25 @@ class PrefixScript extends InputBlock {
       return false
     }
     var regex = ['^']
-    if (!this.isScoped) {
+    if (this.isScoped) {
+      if (this.args.match(/^r/i)) {
+        regex.push('(.+)')
+      } else if (this.args.match(/^o/i)) {
+        regex.push('(.*)')
+      }
+    } else {
       regex.push(this.prefix)
       if (this.space) {
         regex.push(' ')
       }
-    }
-    if (this.args.match(/^r/i)) {
-      regex.push('(.+)')
-    } else if (this.args.match(/^o/i)) {
-      regex.push('(.*)')
+      if (this.args.match(/^r/i)) {
+        regex.push('(.+)')
+      } else if (this.args.match(/^o/i)) {
+        regex.push('(.*)')
+        if (this.space) {
+          regex.push('$|^' + this.prefix)
+        }
+      }
     }
     regex.push('$')
     const respondsTo = input.match(new RegExp(regex.join(''), 'i'))
@@ -52,7 +61,7 @@ class PrefixScript extends InputBlock {
 
   query (input) {
     const respondsTo = this.respondsTo(input)
-    return respondsTo ? respondsTo[1] : ''
+    return respondsTo ? respondsTo[1] || '' : ''
   }
 
   search (input, env = {}) {

--- a/test/app/blocks/input/prefixScript.spec.js
+++ b/test/app/blocks/input/prefixScript.spec.js
@@ -19,8 +19,24 @@ describe('PrefixScript', () => {
         prefixScript.space = true
       })
 
-      it('returns data when space is passed', () => {
-        expect(prefixScript.query('test data')).is.equal('data')
+      describe('when arguments are also required', () => {
+        beforeEach(() => {
+          prefixScript.args = 'Required'
+        })
+
+        it('returns data when space is passed', () => {
+          expect(prefixScript.query('test data')).is.equal('data')
+        })
+      })
+
+      describe('when arguments are optional', () => {
+        beforeEach(() => {
+          prefixScript.args = 'Optional'
+        })
+
+        it('returns empty string when no data is passed', () => {
+          expect(prefixScript.query('test')).is.equal('')
+        })
       })
     })
     describe('when spaces arent required', () => {
@@ -33,6 +49,7 @@ describe('PrefixScript', () => {
       })
     })
   })
+
   describe('respondsTo', () => {
     describe('when arguments and spaces are required', () => {
       beforeEach(() => {
@@ -70,8 +87,8 @@ describe('PrefixScript', () => {
         expect(prefixScript.respondsTo('test ')).to.be.ok
       })
 
-      it('passes when input has space and no argument', () => {
-        expect(prefixScript.respondsTo('test')).to.not.be.ok
+      it('passes when input has no space and no argument', () => {
+        expect(prefixScript.respondsTo('test')).to.be.ok
       })
     })
     describe('when no spaces or arguments are required', () => {


### PR DESCRIPTION
This is just the failing test, not the code to fix it.

Expected:
I want a plugin that accepts both "weather" and "weather location". This is setup via a prefix script:
~~~ json
      {
        "id": "DefaultWeather",
        "type": "PrefixScript",
        "prefix": "weather",
        "space": true,
        "args": "Optional",
        "script": "weather.js",
        "connections": ["DarkSky"]
      },
~~~

The issue here is that this won't accept `weather` but instead `weather ` (with a space at the end).

My suggestion is that if `args` are optional and there are no arguments, the the space is also optional.

The workaround currently is to two prefix blocks:

~~~ json
      {
        "id": "DefaultWeather",
        "type": "PrefixScript",
        "prefix": "weather",
        "space": false,
        "args": "None",
        "script": "weather.js",
        "connections": ["DarkSky"]
      },
      {
        "id": "LocationWeather",
        "type": "PrefixScript",
        "prefix": "weather",
        "space": true,
        "args": "Required",
        "script": "weather.js",
        "connections": ["DarkSky"]
      }
~~~

Making this change will NOT break backwards compatibility, but it will reduce the number of required blocks.