### PR TITLE
#124 - Show zazu window centered on the desktop where the mouse pointer is located

### DIFF
--- a/app/background.js
+++ b/app/background.js
@@ -120,10 +120,10 @@ app.on('ready', function () {
 
   globalEmitter.on('showWindow', () => {
     logger.log('info', 'showing window from manual trigger')
-    let displayBelowCursor = electron.screen.getDisplayNearestPoint(electron.screen.getCursorScreenPoint());
+    let displayBelowCursor = electron.screen.getDisplayNearestPoint(electron.screen.getCursorScreenPoint())
     let xWindowPosition = Math.ceil(((displayBelowCursor.bounds.x + (displayBelowCursor.bounds.width / 2)) - (mainWindow.getSize()[0] / 2)))
     let yWindowPosition = Math.ceil(((displayBelowCursor.bounds.y + (displayBelowCursor.bounds.height / 2)) - (mainWindow.getMaximumSize()[1] / 2)))
-    mainWindow.setPosition(xWindowPosition, yWindowPosition);
+    mainWindow.setPosition(xWindowPosition, yWindowPosition)
     mainWindow.show()
     mainWindow.focus()
   })

--- a/app/background.js
+++ b/app/background.js
@@ -1,3 +1,4 @@
+const electron = require('electron')
 const { dialog, app, globalShortcut } = require('electron')
 const path = require('path')
 
@@ -119,6 +120,10 @@ app.on('ready', function () {
 
   globalEmitter.on('showWindow', () => {
     logger.log('info', 'showing window from manual trigger')
+    let displayBelowCursor = electron.screen.getDisplayNearestPoint(electron.screen.getCursorScreenPoint());
+    let xWindowPosition = Math.ceil(((displayBelowCursor.bounds.x + (displayBelowCursor.bounds.width / 2)) - (mainWindow.getSize()[0] / 2)))
+    let yWindowPosition = Math.ceil(((displayBelowCursor.bounds.y + (displayBelowCursor.bounds.height / 2)) - (mainWindow.getMaximumSize()[1] / 2)))
+    mainWindow.setPosition(xWindowPosition, yWindowPosition);
     mainWindow.show()
     mainWindow.focus()
   })


### PR DESCRIPTION
Zazu will open at the 'center' (centers the maxHeight (400) ui) of the screen where the mouse pointer is located, however will not save the position that the user dragged the window to

TODO:

- Should user-customized positions be saved per screen or should it override the cursor-window-centering functionality? So, if the user drags the window to a new position, should Zazu appear in that position on that particular screen and appear centered (until overridden) on other screens, or should Zazu appear on the user-customized-position no matter where the mouse pointer is?