### PR TITLE
#124 - Show zazu window centered on the desktop where the mouse pointer is located

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Join the chat at https://gitter.im/tinytacoteam/zazu](https://badges.gitter.im/tinytacoteam/zazu.svg)](https://gitter.im/tinytacoteam/zazu?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [![Travis Build Status](https://travis-ci.org/tinytacoteam/zazu.svg?branch=master)](https://travis-ci.org/tinytacoteam/zazu)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/mhfi0vyyo7dygqiu?svg=true)](https://ci.appveyor.com/project/blainesch/zazu)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/mhfi0vyyo7dygqiu/branch/master?svg=true)](https://ci.appveyor.com/project/blainesch/zazu)
 
 Zazu, is a cross platform and fully extensible and open source launcher for
 hackers, creators and dabblers. Download it from the [releases

--- a/app/background.js
+++ b/app/background.js
@@ -120,6 +120,11 @@ app.on('ready', function () {
     }
   })
 
+  mainWindow.on('move', () => {
+    let currentWindowPosition = mainWindow.getPosition()
+    screens.saveWindowPositionOnCurrentScreen(currentWindowPosition[0], currentWindowPosition[1])
+  })
+
   mainWindow.on('moved', () => {
     let currentWindowPosition = mainWindow.getPosition()
     screens.saveWindowPositionOnCurrentScreen(currentWindowPosition[0], currentWindowPosition[1])
@@ -127,7 +132,7 @@ app.on('ready', function () {
 
   globalEmitter.on('showWindow', () => {
     logger.log('info', 'showing window from manual trigger')
-    let position = screens.getCenterPositionOnCurrentScreen(mainWindow.getSize()[0], mainWindow.getMaximumSize()[1])
+    let position = screens.getCenterPositionOnCurrentScreen(mainWindow.getSize()[0])
     if (position) {
       mainWindow.setPosition(position.x, position.y)
     }

--- a/app/background.js
+++ b/app/background.js
@@ -129,7 +129,7 @@ app.on('ready', function () {
     logger.log('info', 'showing window from manual trigger')
     let position = screens.getCenterPositionOnCurrentScreen(mainWindow.getSize()[0], mainWindow.getMaximumSize()[1])
     if (position) {
-       mainWindow.setPosition(position.x, position.y)
+      mainWindow.setPosition(position.x, position.y)
     }
     mainWindow.show()
     mainWindow.focus()

--- a/app/background.js
+++ b/app/background.js
@@ -1,3 +1,4 @@
+const electron = require('electron')
 const { dialog, app, globalShortcut } = require('electron')
 const path = require('path')
 
@@ -98,6 +99,15 @@ app.on('ready', function () {
     },
   })
 
+  const primaryMonitor = !!configuration.primaryMonitor
+  let screens = {}
+
+  if (!primaryMonitor) {
+    electron.screen.getAllDisplays().forEach((display) => {
+      screens[display.id] = display
+    })
+  }
+
   if (debug) mainWindow.webContents.toggleDevTools({mode: 'undocked'})
 
   mainWindow.on('blur', () => {
@@ -117,8 +127,30 @@ app.on('ready', function () {
     }
   })
 
+  mainWindow.on('moved', () => {
+    if (!primaryMonitor) {
+      let updatedPosition = mainWindow.getPosition()
+      let updatedDisplay = electron.screen.getDisplayNearestPoint(electron.screen.getCursorScreenPoint())
+      screens[updatedDisplay.id].customPosition = {
+        x: updatedPosition[0],
+        y: updatedPosition[1],
+      }
+    }
+  })
+
   globalEmitter.on('showWindow', () => {
     logger.log('info', 'showing window from manual trigger')
+    if (!primaryMonitor) {
+      let displayBelowCursor = electron.screen.getDisplayNearestPoint(electron.screen.getCursorScreenPoint())
+      let currentScreen = screens[displayBelowCursor.id]
+      if (currentScreen.customPosition) {
+        mainWindow.setPosition(currentScreen.customPosition.x, currentScreen.customPosition.y)
+      } else {
+        let xWindowPosition = Math.ceil(((displayBelowCursor.bounds.x + (displayBelowCursor.bounds.width / 2)) - (mainWindow.getSize()[0] / 2)))
+        let yWindowPosition = Math.ceil(((displayBelowCursor.bounds.y + (displayBelowCursor.bounds.height / 2)) - (mainWindow.getMaximumSize()[1] / 2)))
+        mainWindow.setPosition(xWindowPosition, yWindowPosition)
+      }
+    }
     mainWindow.show()
     mainWindow.focus()
   })

--- a/app/background.js
+++ b/app/background.js
@@ -99,8 +99,9 @@ app.on('ready', function () {
     },
   })
 
-  let windowWidth = mainWindow.getSize()[0]
-  let screens = new Screens(windowWidth)
+  let screens = new Screens({
+    windowWidth: mainWindow.getSize()[0]
+  })
 
   if (debug) mainWindow.webContents.toggleDevTools({mode: 'undocked'})
 
@@ -134,7 +135,6 @@ app.on('ready', function () {
   })
 
   globalEmitter.on('showWindow', () => {
-    console.log(screens.getAllScreens())
     logger.log('info', 'showing window from manual trigger')
     let position = screens.getCenterPositionOnCurrentScreen()
     if (position) {

--- a/app/background.js
+++ b/app/background.js
@@ -99,7 +99,8 @@ app.on('ready', function () {
     },
   })
 
-  let screens = new Screens()
+  let windowWidth = mainWindow.getSize()[0]
+  let screens = new Screens(windowWidth)
 
   if (debug) mainWindow.webContents.toggleDevTools({mode: 'undocked'})
 
@@ -121,18 +122,21 @@ app.on('ready', function () {
   })
 
   mainWindow.on('move', () => {
+    console.log('move')
     let currentWindowPosition = mainWindow.getPosition()
     screens.saveWindowPositionOnCurrentScreen(currentWindowPosition[0], currentWindowPosition[1])
   })
 
   mainWindow.on('moved', () => {
+    console.log('moved')
     let currentWindowPosition = mainWindow.getPosition()
     screens.saveWindowPositionOnCurrentScreen(currentWindowPosition[0], currentWindowPosition[1])
   })
 
   globalEmitter.on('showWindow', () => {
+    console.log(screens.getAllScreens())
     logger.log('info', 'showing window from manual trigger')
-    let position = screens.getCenterPositionOnCurrentScreen(mainWindow.getSize()[0])
+    let position = screens.getCenterPositionOnCurrentScreen()
     if (position) {
       mainWindow.setPosition(position.x, position.y)
     }

--- a/app/background.js
+++ b/app/background.js
@@ -100,7 +100,7 @@ app.on('ready', function () {
   })
 
   let screens = new Screens({
-    windowWidth: mainWindow.getSize()[0]
+    windowWidth: mainWindow.getSize()[0],
   })
 
   if (debug) mainWindow.webContents.toggleDevTools({mode: 'undocked'})
@@ -123,13 +123,11 @@ app.on('ready', function () {
   })
 
   mainWindow.on('move', () => {
-    console.log('move')
     let currentWindowPosition = mainWindow.getPosition()
     screens.saveWindowPositionOnCurrentScreen(currentWindowPosition[0], currentWindowPosition[1])
   })
 
   mainWindow.on('moved', () => {
-    console.log('moved')
     let currentWindowPosition = mainWindow.getPosition()
     screens.saveWindowPositionOnCurrentScreen(currentWindowPosition[0], currentWindowPosition[1])
   })

--- a/app/lib/configuration.js
+++ b/app/lib/configuration.js
@@ -35,6 +35,7 @@ class Configuration {
       this.plugins = data.plugins
       this.theme = data.theme
       this.hotkey = data.hotkey
+      this.primaryMonitor = data.primaryMonitor
       this.disableAnalytics = data.disableAnalytics
       this.debug = data.debug
       this.loaded = true

--- a/app/lib/screens.js
+++ b/app/lib/screens.js
@@ -5,7 +5,7 @@ const configuration = require('../lib/configuration')
 const primaryMonitor = !!configuration.primaryMonitor
 
 class Screens {
-  constructor() {
+  constructor () {
     this.screenModule = electron.screen
     this.screens = {}
 
@@ -16,7 +16,7 @@ class Screens {
     }
   }
 
-  saveWindowPositionOnCurrentScreen(currentWindowPositionX, currentWindowPositionY) {
+  saveWindowPositionOnCurrentScreen (currentWindowPositionX, currentWindowPositionY) {
     if (!primaryMonitor) {
       let currentDisplay = this.getDisplayBelowCursor()
       this.screens[currentDisplay.id].customPosition = {
@@ -25,12 +25,12 @@ class Screens {
       }
     }
   }
-  
-  getCenterPositionOnCurrentScreen(windowWidth, windowMaxHeight) {
+
+  getCenterPositionOnCurrentScreen (windowWidth, windowMaxHeight) {
     if (!primaryMonitor) {
       let currentScreen = this.getCurrentScreen()
-      let centerPosition = { 
-        x: 0, 
+      let centerPosition = {
+        x: 0,
         y: 0,
       }
       if (currentScreen.customPosition) {
@@ -45,14 +45,13 @@ class Screens {
     return null
   }
 
-  getDisplayBelowCursor() {
+  getDisplayBelowCursor () {
     return this.screenModule.getDisplayNearestPoint(this.screenModule.getCursorScreenPoint())
   }
 
-  getCurrentScreen() {
+  getCurrentScreen () {
     return this.screens[this.getDisplayBelowCursor().id]
   }
 }
-
 
 module.exports = Screens

--- a/app/lib/screens.js
+++ b/app/lib/screens.js
@@ -31,7 +31,7 @@ class Screens {
     }
   }
 
-  getCenterPositionOnCurrentScreen (windowWidth, windowMaxHeight) {
+  getCenterPositionOnCurrentScreen (windowWidth) {
     if (!primaryMonitor) {
       let currentScreen = this.getCurrentScreen()
       let centerPosition = {
@@ -43,7 +43,7 @@ class Screens {
         centerPosition.y = currentScreen.customPosition.y
       } else {
         centerPosition.x = Math.ceil(((currentScreen.bounds.x + (currentScreen.bounds.width / 2)) - (windowWidth / 2)))
-        centerPosition.y = Math.ceil(((currentScreen.bounds.y + (currentScreen.bounds.height / 2)) - (windowMaxHeight / 2)))
+        centerPosition.y = Math.ceil(currentScreen.bounds.y + (currentScreen.bounds.height * 0.33))
       }
       return centerPosition
     }

--- a/app/lib/screens.js
+++ b/app/lib/screens.js
@@ -21,14 +21,27 @@ class Screens {
     })
   }
 
-  saveWindowPositionOnCurrentScreen (currentWindowPositionX, currentWindowPositionY) {
+  saveWindowPositionOnCurrentScreen (currentWindowPositionX, currentWindowPositionY, flag) {
     if (!primaryMonitor) {
-      let currentDisplay = this.getDisplayBelowCursor()
+      let currentDisplay = this.getCurrentScreen()
       if (currentDisplay.id === this.screenModule.getDisplayNearestPoint({x: currentWindowPositionX, y: currentWindowPositionY}).id) {
-        this.screens[currentDisplay.id].customPosition = {
+        // save previous position
+        if (currentDisplay.customPosition) {
+          currentDisplay.lastPosition = currentDisplay.customPosition
+        }
+        currentDisplay.customPosition = {
           x: currentWindowPositionX,
           y: currentWindowPositionY,
+          time: Date.now(),
         }
+      } else {
+        let timeDiff = (Date.now() - currentDisplay.customPosition.time)
+        // if second move event fired in quick succession
+        if (timeDiff < 50) {
+          // replace current position with last to fix linux duplicate 'move' event bug
+          currentDisplay.customPosition = currentDisplay.lastPosition
+        }
+      }
     }
   }
 

--- a/app/lib/screens.js
+++ b/app/lib/screens.js
@@ -7,13 +7,18 @@ const primaryMonitor = !!configuration.primaryMonitor
 class Screens {
   constructor () {
     this.screenModule = electron.screen
-    this.screens = {}
-
     if (!primaryMonitor) {
-      this.screenModule.getAllDisplays().forEach((display) => {
-        this.screens[display.id] = display
-      })
+      this.resetScreens()
     }
+    this.screenModule.on('display-added', () => {
+      this.resetScreens()
+    })
+    this.screenModule.on('display-removed', () => {
+      this.resetScreens()
+    })
+    this.screenModule.on('display-metrics-changed', () => {
+      this.resetScreens()
+    })
   }
 
   saveWindowPositionOnCurrentScreen (currentWindowPositionX, currentWindowPositionY) {
@@ -51,6 +56,13 @@ class Screens {
 
   getCurrentScreen () {
     return this.screens[this.getDisplayBelowCursor().id]
+  }
+
+  resetScreens () {
+    this.screens = {}
+    this.screenModule.getAllDisplays().forEach((display) => {
+      this.screens[display.id] = display
+    })
   }
 }
 

--- a/app/lib/screens.js
+++ b/app/lib/screens.js
@@ -1,12 +1,3 @@
-// FIXING THIS
-/*
-  Figured out that there's a position saving issue when Zazu is open on one screen
-and then the user tries to close it when the mouse is on a different screen.
-
-Trying to fix this by comparing the screen on which the window is and the screen where the mouse is on save
-If on save there is a difference, do not proceed with updating customPosition
-*/
-
 const electron = require('electron')
 
 const configuration = require('../lib/configuration')
@@ -14,31 +5,30 @@ const configuration = require('../lib/configuration')
 const primaryMonitor = !!configuration.primaryMonitor
 
 class Screens {
-  constructor (windowWidth) {
+  constructor (options) {
     this.screenModule = electron.screen
     if (!primaryMonitor) {
-      this.resetScreens(windowWidth)
+      this.resetScreens(options.windowWidth)
     }
     this.screenModule.on('display-added', () => {
-      this.resetScreens(windowWidth)
+      this.resetScreens(options.windowWidth)
     })
     this.screenModule.on('display-removed', () => {
-      this.resetScreens(windowWidth)
+      this.resetScreens(options.windowWidth)
     })
     this.screenModule.on('display-metrics-changed', () => {
-      this.resetScreens(windowWidth)
+      this.resetScreens(options.windowWidth)
     })
   }
 
   saveWindowPositionOnCurrentScreen (currentWindowPositionX, currentWindowPositionY) {
     if (!primaryMonitor) {
       let currentDisplay = this.getDisplayBelowCursor()
-      if (currentDisplay.id === this.screenModule.getDisplayNearestPoint(currentWindowPositionX, currentWindowPositionY).id) {
+      if (currentDisplay.id === this.screenModule.getDisplayNearestPoint({x: currentWindowPositionX, y: currentWindowPositionY}).id) {
         this.screens[currentDisplay.id].customPosition = {
           x: currentWindowPositionX,
           y: currentWindowPositionY,
         }
-      }
     }
   }
 

--- a/app/lib/screens.js
+++ b/app/lib/screens.js
@@ -1,0 +1,58 @@
+const electron = require('electron')
+
+const configuration = require('../lib/configuration')
+
+const primaryMonitor = !!configuration.primaryMonitor
+
+class Screens {
+  constructor() {
+    this.screenModule = electron.screen
+    this.screens = {}
+
+    if (!primaryMonitor) {
+      this.screenModule.getAllDisplays().forEach((display) => {
+        this.screens[display.id] = display
+      })
+    }
+  }
+
+  saveWindowPositionOnCurrentScreen(currentWindowPositionX, currentWindowPositionY) {
+    if (!primaryMonitor) {
+      let currentDisplay = this.getDisplayBelowCursor()
+      this.screens[currentDisplay.id].customPosition = {
+        x: currentWindowPositionX,
+        y: currentWindowPositionY,
+      }
+    }
+  }
+  
+  getCenterPositionOnCurrentScreen(windowWidth, windowMaxHeight) {
+    if (!primaryMonitor) {
+      let currentScreen = this.getCurrentScreen()
+      let centerPosition = { 
+        x: 0, 
+        y: 0,
+      }
+      if (currentScreen.customPosition) {
+        centerPosition.x = currentScreen.customPosition.x
+        centerPosition.y = currentScreen.customPosition.y
+      } else {
+        centerPosition.x = Math.ceil(((currentScreen.bounds.x + (currentScreen.bounds.width / 2)) - (windowWidth / 2)))
+        centerPosition.y = Math.ceil(((currentScreen.bounds.y + (currentScreen.bounds.height / 2)) - (windowMaxHeight / 2)))
+      }
+      return centerPosition
+    }
+    return null
+  }
+
+  getDisplayBelowCursor() {
+    return this.screenModule.getDisplayNearestPoint(this.screenModule.getCursorScreenPoint())
+  }
+
+  getCurrentScreen() {
+    return this.screens[this.getDisplayBelowCursor().id]
+  }
+}
+
+
+module.exports = Screens

--- a/app/lib/screens.js
+++ b/app/lib/screens.js
@@ -1,3 +1,12 @@
+// FIXING THIS
+/*
+  Figured out that there's a position saving issue when Zazu is open on one screen
+and then the user tries to close it when the mouse is on a different screen.
+
+Trying to fix this by comparing the screen on which the window is and the screen where the mouse is on save
+If on save there is a difference, do not proceed with updating customPosition
+*/
+
 const electron = require('electron')
 
 const configuration = require('../lib/configuration')
@@ -5,45 +14,40 @@ const configuration = require('../lib/configuration')
 const primaryMonitor = !!configuration.primaryMonitor
 
 class Screens {
-  constructor () {
+  constructor (windowWidth) {
     this.screenModule = electron.screen
     if (!primaryMonitor) {
-      this.resetScreens()
+      this.resetScreens(windowWidth)
     }
     this.screenModule.on('display-added', () => {
-      this.resetScreens()
+      this.resetScreens(windowWidth)
     })
     this.screenModule.on('display-removed', () => {
-      this.resetScreens()
+      this.resetScreens(windowWidth)
     })
     this.screenModule.on('display-metrics-changed', () => {
-      this.resetScreens()
+      this.resetScreens(windowWidth)
     })
   }
 
   saveWindowPositionOnCurrentScreen (currentWindowPositionX, currentWindowPositionY) {
     if (!primaryMonitor) {
       let currentDisplay = this.getDisplayBelowCursor()
-      this.screens[currentDisplay.id].customPosition = {
-        x: currentWindowPositionX,
-        y: currentWindowPositionY,
+      if (currentDisplay.id === this.screenModule.getDisplayNearestPoint(currentWindowPositionX, currentWindowPositionY).id) {
+        this.screens[currentDisplay.id].customPosition = {
+          x: currentWindowPositionX,
+          y: currentWindowPositionY,
+        }
       }
     }
   }
 
-  getCenterPositionOnCurrentScreen (windowWidth) {
+  getCenterPositionOnCurrentScreen () {
     if (!primaryMonitor) {
       let currentScreen = this.getCurrentScreen()
       let centerPosition = {
-        x: 0,
-        y: 0,
-      }
-      if (currentScreen.customPosition) {
-        centerPosition.x = currentScreen.customPosition.x
-        centerPosition.y = currentScreen.customPosition.y
-      } else {
-        centerPosition.x = Math.ceil(((currentScreen.bounds.x + (currentScreen.bounds.width / 2)) - (windowWidth / 2)))
-        centerPosition.y = Math.ceil(currentScreen.bounds.y + (currentScreen.bounds.height * 0.33))
+        x: currentScreen.customPosition.x,
+        y: currentScreen.customPosition.y,
       }
       return centerPosition
     }
@@ -58,10 +62,18 @@ class Screens {
     return this.screens[this.getDisplayBelowCursor().id]
   }
 
-  resetScreens () {
+  getAllScreens () {
+    return this.screens
+  }
+
+  resetScreens (windowWidth) {
     this.screens = {}
     this.screenModule.getAllDisplays().forEach((display) => {
       this.screens[display.id] = display
+      this.screens[display.id].customPosition = {
+        x: Math.ceil(((display.bounds.x + (display.bounds.width / 2)) - (windowWidth / 2))),
+        y: Math.ceil(display.bounds.y + (display.bounds.height * 0.33)),
+      }
     })
   }
 }

--- a/app/templates/zazurc.json
+++ b/app/templates/zazurc.json
@@ -1,6 +1,7 @@
 {
   "hotkey": "alt+space",
   "theme": "tinytacoteam/zazu-light-theme",
+  "primaryMonitor": false,
   "plugins": [
     "tinytacoteam/zazu-calculator",
     "tinytacoteam/zazu-file-finder",

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -26,6 +26,7 @@ twitterUsername: zazuapp
 dribbbleUsername:
 codepenUsername:
 githubUsername: tinytacoteam
+gitterUsername: tinytacoteam/zazu
 
 # Build settings
 permalink: /:year/:month/:title

--- a/docs/_documentation/configuration.md
+++ b/docs/_documentation/configuration.md
@@ -17,7 +17,8 @@ basic usage.
 {
   "hotkey": "alt+space",
   "theme": "tinytacoteam/dark-theme",
-  "plugins": []
+  "plugins": [],
+  "primaryMonitor": false
 }
 ~~~~
 
@@ -69,6 +70,23 @@ you can use to configure it's behavior.
   ]
 }
 ~~~~
+
+### Primary Monitor
+
+This determines whether Zazu opens in the center of the primary display each 
+time it is toggled. 
+
+`true` means Zazu will open in the center of the primary display the first 
+time it is toggled after launching the application. Any update to Zazu's 
+screen position will be saved and Zazu will open at the new position each 
+time it is toggled.
+
+`false` means Zazu will open at the center of any screen that the cursor is
+hovering over. Any updates to Zazu's position will be saved for that
+particular screen but not the others. Each screen's custom Zazu position
+will be used to position Zazu on that screen in subsequent toggles.
+
+Primary Monitor is `false` by default.
 
 ### Analytics
 

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -12,6 +12,7 @@
       {% if site.githubUsername %}<a href="https://github.com/{{ site.githubUsername }}">Github</a>{% endif %}
       {% if site.dribbbleUsername %}<a href="https://dribbble.com/{{ site.dribbbleUsername }}">Dribbble</a>{% endif %}
       {% if site.codepenUsername %}<a href="http://codepen.io/{{ site.codepenUsername }}">CodePen</a>{% endif %}
+      {% if site.gitterUsername %}<a href="https://gitter.im/{{ site.gitterUsername }}">Gitter Chat</a>{% endif %}
     </p>
   </div>
 </footer>


### PR DESCRIPTION
Zazu will open at the 'center' (centers the maxHeight (400) ui) of the screen where the mouse pointer is located.
The custom position (user drag) for Zazu will be saved per screen.

**ISSUES**

- [FIXED] **summary:** I noticed a problem with centering Zazu if a display is removed while Zazu is running (not necessarily toggled). Zazu may end up on one screen even when the cursor is on another after the user removes a display while Zazu is running. **reproduce:** Reproduce by using 3 displays, set a custom position for each screen somewhere close to the edge of the screen, remove a display, try toggling Zazu on different screens. **fix:** Electron's Screen emits the 'display-removed' and 'display-added' events when those events take place. Might reset any saved screen / browser-window data (having to do with custom positioning) when one of those events are caught.
- [FIXED] **summary:** Positioning zazu between screens will save Zazu's position for that screen, but if most of Zazu is on a different screen, Electron will automatically render it in whole on the screen with the majority of the UI saved. **reproduce:** Reposition Zazu to be mostly off the screen where you toggled it. Re-toggle it on the same screen, Zazu should render on the other screen where most of it was. **fix:** the fix above ^ took care of this. Wont ever save Zazu's position for one screen on another.
- [FIXED] **summary:** background.js is probably the wrong place for a bunch of positioning logic. Not sure where to attach this stuff. **fix:** Thought about creating a screenHelper, or adding a positioning object to mainWindow, ex: `mainWindow.position.setCustom(x, y, display)` / `mainWindow.position.setCenter(display)` , in helpers/window.js/