### PR TITLE
Allown `npm install` to take up to 25 seconds.

### DIFF
--- a/features/step_definitions/myStepDefinitions.js
+++ b/features/step_definitions/myStepDefinitions.js
@@ -33,7 +33,7 @@ class World {
 
   open () {
     return this.app.start().then(() => {
-      const time = this.profileType === 'calculator' ? 15 * 1000 : 5 * 1000
+      const time = this.profileType === 'calculator' ? 25 * 1000 : 5 * 1000
       return wait(time) // give it time to load plugins
     })
   }


### PR DESCRIPTION
We've been having sporadic failures on the cucumber spec that tests a plugin can install. After reviewing the log we are waiting on the `npm install` to finish.

Alternatively we could install a plugin without dependencies, but I like knowing `npm install` still works.

reviewer: @afaur 