### PR TITLE
Fix repeating plugin path issue in 'icon' path

### DIFF
--- a/app/packages/plugin.js
+++ b/app/packages/plugin.js
@@ -164,7 +164,7 @@ class Plugin extends Package {
               return results.map((result) => {
                 const icon = result.icon || this.plugin.icon || 'fa-bolt'
                 const isFontAwesome = icon.indexOf('fa-') === 0 && icon.indexOf('.') === -1
-                result.icon = isFontAwesome ? icon : path.join(this.path, icon)
+                result.icon = isFontAwesome ? icon : (icon.indexOf(this.path) === 0 ? icon : path.join(this.path, icon))
                 result.previewCss = this.plugin.css
                 result.pluginName = this.url
                 result.blockId = input.id


### PR DESCRIPTION
During the development of a plugin, I found a bug which cause `path.join` icon path multiple times if the icon is relative path.

At first, the result from the plugin is correct:

```json
{
  "results": [{
    "icon": "/Users/taowang/.zazu/plugins/tinytacoteam/zazu-file-finder/data/icons/QQMusic.app-5d7f27eea6e5a52399ea9800df1dc7b0cc3f071c.png",
    "title": "QQMusic",
    "subtitle": "Version: 39619",
    "value": "/Applications/QQMusic.app",
    "id": "/Applications/QQMusic.app",
    "pluginName": "tinytacoteam/zazu-file-finder",
    "blockId": "FindApp"
  }, {
    "icon": "/Users/taowang/.zazu/plugins/tinytacoteam/zazu-file-finder/data/icons/QQ.app-778713fb2c944199fef524595356bf1c6c991e36.png",
    "title": "QQ",
    "subtitle": "Version: 24630",
    "value": "/Applications/QQ.app",
    "id": "/Applications/QQ.app",
    "pluginName": "tinytacoteam/zazu-file-finder",
    "blockId": "FindApp"
  }],
  "plugin": "tinytacoteam/zazu-file-finder",
  "block": "FindApp",
  "level": "info",
  "message": "Script Results",
  "timestamp": "2017-01-31T07:33:41.482Z"
}
```

The icon path is correct the first time: `/Users/taowang/.zazu/plugins/tinytacoteam/zazu-file-finder/data/icons/QQMusic.app-5d7f27eea6e5a52399ea9800df1dc7b0cc3f071c.png`.

Then, the second time I use the plugin for the same search string, the result will be:

```json
{
  "results": [{
    "icon": "/Users/taowang/.zazu/plugins/tinytacoteam/zazu-file-finder/Users/taowang/.zazu/plugins/tinytacoteam/zazu-file-finder/Users/taowang/.zazu/plugins/tinytacoteam/zazu-file-finder/Users/taowang/.zazu/plugins/tinytacoteam/zazu-file-finder/data/icons/QQMusic.app-5d7f27eea6e5a52399ea9800df1dc7b0cc3f071c.png",
    "title": "QQMusic",
    "subtitle": "Version: 39619",
    "value": "/Applications/QQMusic.app",
    "id": "/Applications/QQMusic.app",
    "pluginName": "tinytacoteam/zazu-file-finder",
    "blockId": "FindApp"
  }, {
    "icon": "/Users/taowang/.zazu/plugins/tinytacoteam/zazu-file-finder/Users/taowang/.zazu/plugins/tinytacoteam/zazu-file-finder/Users/taowang/.zazu/plugins/tinytacoteam/zazu-file-finder/Users/taowang/.zazu/plugins/tinytacoteam/zazu-file-finder/data/icons/QQ.app-778713fb2c944199fef524595356bf1c6c991e36.png",
    "title": "QQ",
    "subtitle": "Version: 24630",
    "value": "/Applications/QQ.app",
    "id": "/Applications/QQ.app",
    "pluginName": "tinytacoteam/zazu-file-finder",
    "blockId": "FindApp"
  }],
  "plugin": "tinytacoteam/zazu-file-finder",
  "block": "FindApp",
  "level": "info",
  "message": "Script Results",
  "timestamp": "2017-01-31T07:33:45.634Z"
}
```

As you can see, the icon path contains multiple plugin path: `/Users/taowang/.zazu/plugins/tinytacoteam/zazu-file-finder/Users/taowang/.zazu/plugins/tinytacoteam/zazu-file-finder/Users/taowang/.zazu/plugins/tinytacoteam/zazu-file-finder/Users/taowang/.zazu/plugins/tinytacoteam/zazu-file-finder/data/icons/QQMusic.app-5d7f27eea6e5a52399ea9800df1dc7b0cc3f071c.png`

I fixed this bug by checking whether the `icon` already contains the plugin path, however, it's might be better to `Object.assign({}, icon)`, so the result will be immutable. Just let me know what do you think.

Signed-off-by: Tao Wang <twang2218@gmail.com>
