### PR TITLE
Add debounce for input scripts.

### DIFF
--- a/app/blocks/input/keyword.js
+++ b/app/blocks/input/keyword.js
@@ -19,17 +19,15 @@ class Keyword extends InputBlock {
 
   search (input, env = {}) {
     this.logger.log('info', 'Rendering keyword', { input })
-    return new Promise((resolve) => {
-      resolve([
-        {
-          blockRank: 2,
-          title: this.title,
-          subtitle: this.subtitle,
-          value: this.keyword,
-          icon: this.icon,
-        },
-      ])
-    })
+    return Promise.resolve([
+      {
+        blockRank: 2,
+        title: this.title,
+        subtitle: this.subtitle,
+        value: this.keyword,
+        icon: this.icon,
+      },
+    ])
   }
 }
 

--- a/app/blocks/input/prefixScript.js
+++ b/app/blocks/input/prefixScript.js
@@ -67,7 +67,14 @@ class PrefixScript extends InputBlock {
   search (input, env = {}) {
     const query = this.query(input)
     this.logger.log('verbose', 'Executing Script', { query })
-    return this._ensurePromise(this.script(query, env)).then((results) => {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        timeout === this.timeout ? resolve() : reject('Debounced')
+      }, this.debounce)
+      this.timeout = timeout
+    }).then(() => {
+      return this._ensurePromise(this.script(query, env))
+    }).then((results) => {
       this.logger.log('info', 'Script Results', { results })
       return this._validateResults(results.map((result) => {
         return Object.assign({}, result, {

--- a/app/blocks/input/rootScript.js
+++ b/app/blocks/input/rootScript.js
@@ -41,7 +41,14 @@ class RootScript extends InputBlock {
   search (input, env = {}) {
     const query = this.query(input)
     this.logger.log('verbose', 'Executing Script', { query })
-    return this._ensurePromise(this.script.search(query, env)).then((results) => {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        timeout === this.timeout ? resolve() : reject('Debounced')
+      }, this.debounce)
+      this.timeout = timeout
+    }).then(() => {
+      return this._ensurePromise(this.script.search(query, env))
+    }).then((results) => {
       this.logger.log('info', 'Script Results', { results })
       return this._validateResults(results.map((result) => {
         return Object.assign({}, result, {

--- a/app/blocks/inputBlock.js
+++ b/app/blocks/inputBlock.js
@@ -7,6 +7,7 @@ class InputBlock extends Block {
     super(data)
     this.pluginId = data.pluginId
     this.isScoped = null
+    this.debounce = data.debounce || 0
   }
 
   isActive () {

--- a/docs/_documentation/blocks.md
+++ b/docs/_documentation/blocks.md
@@ -149,15 +149,18 @@ scripts should be able to handle a [`SIGKILL`](http://www.gnu.org/software/libc/
 
 ### Root Script
 
-This allows you to execute a node script with a prefix.
+This allows you to execute a node script without a prefix.
 
 * `script` *string*: Path to the node file to execute.
+* `debounce` *int*: How long in milliseconds we should wait between calls,
+  useful for resource intensive or slow running plugins. Defaults to `0`.
 
 ~~~ javascript
 [{
   "id": "Calculator",
   "type": "RootScript",
   "script": "calculator.js",
+  "debounce": 100,
   "connections": ["Copy"]
 }]
 ~~~
@@ -211,6 +214,8 @@ This allows you to execute a node script with a prefix.
 * `space` *boolean*: If a space should be between the Prefix and the user input.
 * `args` *string*: Specifies if you want arguments. Possibles values are `Required`, `Optional` and `None`.
 * `script` *string*: Path to the node file to execute.
+* `debounce` *int*: How long in milliseconds we should wait between calls,
+  useful for resource intensive or slow running plugins. Defaults to `0`.
 
 ~~~ json
 [{
@@ -220,6 +225,7 @@ This allows you to execute a node script with a prefix.
   "space": true,
   "args": "Required",
   "script": "calculator.js",
+  "debounce": 100,
   "connections": ["Copy"]
 }]
 ~~~~


### PR DESCRIPTION
Would fix #125 

To test:
* Delete all plugins except `tinytacoteam/zazu-calculator`
* Manually add a `debounce` to `1000` in the `zazu.json` file inside of the plugin
* Start this feature branch
* Type in `1`, wait for results, types `2`, wait for results, etc.