### PR TITLE
show 'no plugins' container when no plugins in config

### DIFF
--- a/app/components/noplugins.js
+++ b/app/components/noplugins.js
@@ -1,0 +1,33 @@
+const React = require('react')
+const Style = require('./style')
+const {shell} = require('electron')
+
+
+const NoPlugins = () => {
+  let css = `
+    body {
+      background-color: #5CC7B2;
+      margin: 0;
+    }
+    h2, h3 {
+      margin: 0;
+      padding: 10px;
+      display: block;
+      color: #fff;
+      text-align: center;
+    }
+    a {
+      color: #EBEBEB;
+    }
+  `
+
+  return (
+    <div className='container'>
+      <h2 className='loader'>Zazu requires plugins to work!</h2>
+      <h3 className='loader'>Have a look at the <a href='#' onClick={ () => { shell.openExternal('http://zazuapp.org/plugins/') } }>Zazu Plugins</a> page.</h3>
+      <Style css={css}/>
+    </div>
+  )
+}
+
+module.exports = NoPlugins

--- a/app/containers/pluginWrapper.js
+++ b/app/containers/pluginWrapper.js
@@ -7,6 +7,7 @@ const globalEmitter = require('../lib/globalEmitter')
 const notification = require('../lib/notification')
 const DatabaseWrapper = require('./databaseWrapper')
 const LoadingSpinner = require('../components/loadingSpinner.js')
+const NoPlugins = require('../components/noplugins.js')
 
 const PluginWrapper = React.createClass({
   getInitialState () {
@@ -80,6 +81,11 @@ const PluginWrapper = React.createClass({
         title: 'Plugins loaded',
         message: 'Your plugins have been loaded',
       })
+    }).catch(() => {
+      notification.push({
+        title: 'No Plugins',
+        message: 'There are no plugins to load',
+      })
     })
   },
 
@@ -105,6 +111,10 @@ const PluginWrapper = React.createClass({
       }
     })
     this.setState({ plugins, loaded: 0 })
+    if (plugins.length === 0) {
+      this.context.logger.log('info', 'no plugins to load')
+      throw new Error('no plugins to load')
+    }
     return Promise.all(plugins.map((pluginObj) => {
       return pluginObj.load().then(() => {
         const loaded = this.state.loaded + 1
@@ -192,11 +202,17 @@ const PluginWrapper = React.createClass({
     const { query, theme, results } = this.state
     const noPlugins = this.state.plugins.length === 0
     const stillLoading = this.state.loaded !== this.state.plugins.length
-    if (stillLoading || noPlugins) {
+    if (stillLoading) {
       return (
         <LoadingSpinner
           loaded={this.state.loaded}
           total={this.state.plugins.length}/>
+      )
+    }
+
+    if (noPlugins) {
+      return (
+        <NoPlugins/>
       )
     }
 


### PR DESCRIPTION
Addresses https://github.com/tinytacoteam/zazu/issues/190 with a loadingspinner-like green Zazu container prompting the user to visit the Zazu Plugins page.

![noplugins](https://cloud.githubusercontent.com/assets/11944012/22534782/8c9847d0-e8c4-11e6-8fe2-afd15047df58.gif)
