### PR TITLE
Add support for absolute path in icon

### DIFF
--- a/app/packages/plugin.js
+++ b/app/packages/plugin.js
@@ -163,13 +163,16 @@ class Plugin extends Package {
             .then((results = []) => {
               return results.map((result) => {
                 const icon = result.icon || this.plugin.icon || 'fa-bolt'
-                const isFontAwesome = icon.indexOf('fa-') === 0 && icon.indexOf('.') === -1
-                result.icon = isFontAwesome ? icon : (icon.indexOf(this.path) === 0 ? icon : path.join(this.path, icon))
-                result.previewCss = this.plugin.css
-                result.pluginName = this.url
-                result.blockId = input.id
-                result.next = this.next.bind(this, result)
-                return result
+                const isFontAwesome = (icon.indexOf('fa-') === 0 && icon.indexOf('.') === -1)
+                const isAbsolutePath = (icon.indexOf('/') === 0 || icon.indexOf(this.path) === 0)
+                const finalResult = Object.assign({}, result, {
+                  icon: (isFontAwesome || isAbsolutePath) ? icon : path.join(this.path, icon),
+                  previewCss: this.plugin.css,
+                  pluginName: this.url,
+                  blockId: input.id,
+                })
+                finalResult.next = this.next.bind(this, finalResult)
+                return finalResult
               })
             })
             .then(tracer.complete)

--- a/features/output_blocks.feature
+++ b/features/output_blocks.feature
@@ -1,4 +1,4 @@
-Feature: Input Blocks
+Feature: Output Blocks
   As a user of Zazu
   I want to use all the available block types
   So I can be more productive


### PR DESCRIPTION
* Only prefix the plugin path to icon path if it's relative path.
* Use `Object.assign()` to create a new object instead of modify the
returned result.

Signed-off-by: Tao Wang <twang2218@gmail.com>

All pull requests should go to `master`, even the documentation is in `master`
under `./docs/`.
