### PR TITLE
Use git to ensure it exists instead of just making sure it's in $PATH.

### DIFF
--- a/app/lib/git.js
+++ b/app/lib/git.js
@@ -1,4 +1,4 @@
-const exec = require('child_process').execFile
+const { execFile, execFileSync } = require('child_process')
 const which = require('which')
 const retry = require('./retry')
 const installStatus = require('./installStatus')
@@ -8,10 +8,18 @@ const path = require('path')
 
 const git = (args, options) => {
   return new Promise((resolve, reject) => {
-    exec(gitPath(), args, options || {}, (err) => {
+    execFile(gitPath(), args, options || {}, (err) => {
       err && reject(err) || resolve()
     })
   })
+}
+
+const gitSync = (args) => {
+  try {
+    return execFileSync(gitPath(), args).toString()
+  } catch (e) {
+    return false
+  }
 }
 
 const pull = (name, packagePath) => {
@@ -70,7 +78,7 @@ const gitPath = () => {
 
 const isInstalled = () => {
   try {
-    return gitPath()
+    return gitPath() && !!gitSync(['--version'])
   } catch (e) {
     return false
   }


### PR DESCRIPTION
Fixes #197 

The issue is basically on a brand new mac, by default, you have to accept terms
before GIT can work. So GIT does exist in the PATH, but every command you run
has a failure code and tells you to accept the xcode terms of service.

The solution is to not only check if GIT is in your path, but also attempt to
use it (`git --version` for example) before we determine if the user has git
installed on their box, allowing us to fall back to GitHub correctly.

I teseted this by changing the `git.js` file like so and running it:

~~~ diff
diff --git a/app/lib/git.js b/app/lib/git.js
index 87fe845..762fd3d 100644
--- a/app/lib/git.js
+++ b/app/lib/git.js
@@ -73,7 +73,7 @@ const clone = (name, packagePath) => {
 }

 const gitPath = () => {
-  return which.sync('git')
+  return '/usr/bin/git'
 }

 const isInstalled = () => {
@@ -84,4 +84,6 @@ const isInstalled = () => {
   }
 }

+console.log('isInstalled', isInstalled())
+
 module.exports = { clone, pull, git, isInstalled }
~~~

I also re-installed xcode so I had to re-agree to the terms.

All pull requests should go to `master`, even the documentation is in `master`
under `./docs/`.
