### PR TITLE
Force scoped blocks to always return results.

### DIFF
--- a/app/blocks/input/prefixScript.js
+++ b/app/blocks/input/prefixScript.js
@@ -33,11 +33,7 @@ class PrefixScript extends InputBlock {
     }
     var regex = ['^']
     if (this.isScoped) {
-      if (this.args.match(/^r/i)) {
-        regex.push('(.+)')
-      } else if (this.args.match(/^o/i)) {
-        regex.push('(.*)')
-      }
+      regex.push('(.*)')
     } else {
       regex.push(this.prefix)
       if (this.space) {
@@ -80,6 +76,16 @@ class PrefixScript extends InputBlock {
           blockRank: 3,
         })
       }))
+    }).then((results) => {
+      if (this.isScoped && results.length === 0) {
+        return [
+          {
+            title: this.id + ' is scoped',
+            subtitle: 'Type to see more...',
+          },
+        ]
+      }
+      return results
     }).catch((error) => {
       this.logger.log('error', 'Script failed', { query, error })
     })

--- a/app/blocks/input/rootScript.js
+++ b/app/blocks/input/rootScript.js
@@ -54,6 +54,16 @@ class RootScript extends InputBlock {
           blockRank: 1,
         })
       }))
+    }).then((results) => {
+      if (this.isScoped && results.length === 0) {
+        return [
+          {
+            title: this.id + ' is scoped',
+            subtitle: 'Type to see more...',
+          },
+        ]
+      }
+      return results
     }).catch((error) => {
       this.logger.log('error', 'Script failed', { query, error })
     })

--- a/app/blocks/inputBlock.js
+++ b/app/blocks/inputBlock.js
@@ -30,9 +30,6 @@ class InputBlock extends Block {
       if (!keys.includes('title')) {
         this.logger.log('error', 'result must contain a title', { result })
       }
-      if (!keys.includes('value')) {
-        this.logger.log('error', 'result must contain a value', { result })
-      }
     })
     return results
   }

--- a/app/components/results.js
+++ b/app/components/results.js
@@ -50,7 +50,10 @@ const Results = React.createClass({
     })
     Mousetrap.bind('enter', () => {
       const { values, handleResultClick, activeIndex } = this.props
-      handleResultClick(values[activeIndex])
+      const result = values[activeIndex]
+      if (result.value) {
+        handleResultClick(result)
+      }
     })
     Mousetrap.bind('esc', () => {
       globalEmitter.emit('hideWindow')


### PR DESCRIPTION
Fixes #36

This makes it so scoped blocks always ask the plugin for results, even
if arguments are required, if the plugin doesn't provide one give the
user a generated result that's not clickable.

Breaking changes:

* Calling scoped blocks with empty query [plugin contract]
* Value is no longer required [plugin contract]
* Not all results are clickable [core behavior]

Because it's a major change it might be worth waiting to merge this pr until we are ready for a major bump. Thoughts?

To test the default behavior:
* Ensure you have the latest chrome bookmarks plugin
* Add an external block:

~~~ diff
diff --git a/zazu.json b/zazu.json
index 8bda0c7..64e7d67 100644
--- a/zazu.json
+++ b/zazu.json
@@ -4,6 +4,14 @@
   "description": "Chrome bookmark searcher for Zazu.",
   "icon": "assets/chrome.png",
   "blocks": {
+    "external": [
+      {
+        "id": "hotkey",
+        "type": "Hotkey",
+        "hotkey": "cmd+shift+b",
+        "connections": ["Chrome Bookmarks"]
+      }
+    ],
     "input": [
       {
         "id": "Chrome Bookmarks",
~~~

* Launch this branch
* Try the hokey `cmd+shift+b` to see the generated result

![screen shot 2017-02-05 at 9 34 59 pm](https://cloud.githubusercontent.com/assets/769039/22635844/8be4ec38-ebeb-11e6-944f-998496fd9f08.png)

If the user wants more control over the result or icon, we do still allow them to overwrite it:

~~~ diff
diff --git a/search.js b/search.js
index 65648aa..a6d915f 100644
--- a/search.js
+++ b/search.js
@@ -8,7 +8,11 @@ const file = '~/Library/Application Support/Google/Chrome/Default/Bookmarks'

 module.exports = (pluginContext) => {
   return (query, env) => {
-    if (query.length === 0) return Promise.resolve([])
+    if (query.length === 0) return Promise.resolve([{
+      icon: 'fa-music',
+      title: 'Tiny taco team!',
+      subtitle: 'ftw!',
+    }])
     const variables = env || {}
     const bookmarkFile = (variables['file'] || file).replace(/^~/, os.homedir())
     return new Promise((resolve, reject) => {
~~~

![screen shot 2017-02-05 at 9 44 15 pm](https://cloud.githubusercontent.com/assets/769039/22635926/55d1ed34-ebec-11e6-955b-65ec7e6e0e5c.png)
