### PR TITLE
Add zazu-gist.

### DIFF
--- a/docs/_packages/gist.md
+++ b/docs/_packages/gist.md
@@ -1,0 +1,8 @@
+---
+top:         true
+type:        plugin
+title:       "Gist"
+icon:        fa-github-alt
+githuburl:   afaur/zazu-gist
+description: "Create gists from your clipboard contents"
+---

--- a/docs/_pages/plugins.html
+++ b/docs/_pages/plugins.html
@@ -7,7 +7,11 @@ permalink: /plugins/
 {% for package in site.packages %}
     {% if package.type == "plugin" %}
         <a class="package {{ package.type }}" href="https://github.com/{{ package.githuburl }}">
-            <img src="{{ package.image }}" alt="{{ package.title }} Logo" />
+            {% if package.icon %}
+                <i class="fa {{ package.icon }}" aria-hidden="true"></i>
+            {% else %}
+                <img src="{{ package.image }}" alt="{{ package.title }} Logo" />
+            {% endif %}
             <h2>{{ package.title }}</h2>
             <p>{{ package.description }}</p>
         </a>

--- a/docs/_sass/components/_packages.scss
+++ b/docs/_sass/components/_packages.scss
@@ -14,6 +14,10 @@ a.package {
     height: 200px;
   }
 
+  i.fa {
+    font-size: 128px;
+  }
+
   img {
     max-width: 128px;
   }


### PR DESCRIPTION
This also enables you to add a font-awesome icon instead of an image.