### PR TITLE
Fix cannot output service script exception issue.

### DIFF
--- a/app/blocks/external/serviceScript.js
+++ b/app/blocks/external/serviceScript.js
@@ -31,23 +31,18 @@ class ServiceScript extends ExternalBlock {
   start () {
     return new Promise((resolve) => {
       setTimeout(resolve, this.interval)
-    }).then(() => {
-      return this.handle()
-    })
+    }).then(() => this.handle())
   }
 
   handle () {
     if (!this.script) {
-      this.logger.log('error', 'Plugin failed to load', {
-        message: this.loadError.message,
-        stack: this.loadError.stack.split('\n'),
-      })
+      this.logger.error('Plugin failed to load', this.loadError)
       return Promise.resolve()
     }
-    return this._ensurePromise(this.script(this.options)).then(() => {
-      this.start()
-    }).catch((error) => {
-      this.logger.log('error', 'Script failed', { error })
+    return this._ensurePromise(this.script(this.options))
+    .then(() => this.start())
+    .catch((error) => {
+      this.logger.error('Script failed', error)
     })
   }
 }

--- a/app/blocks/input/prefixScript.js
+++ b/app/blocks/input/prefixScript.js
@@ -25,10 +25,7 @@ class PrefixScript extends InputBlock {
 
   respondsTo (input) {
     if (!this.script) {
-      this.logger.log('error', 'Plugin failed to load', {
-        message: this.loadError.message,
-        stack: this.loadError.stack.split('\n'),
-      })
+      this.logger.error('Plugin failed to load', this.loadError)
       return false
     }
     var regex = ['^']
@@ -81,7 +78,7 @@ class PrefixScript extends InputBlock {
         })
       }))
     }).catch((error) => {
-      this.logger.log('error', 'Script failed', { query, error })
+      this.logger.error('Script failed', { query, error })
     })
   }
 }

--- a/app/blocks/input/rootScript.js
+++ b/app/blocks/input/rootScript.js
@@ -22,10 +22,7 @@ class RootScript extends InputBlock {
 
   respondsTo (input) {
     if (!this.script) {
-      this.logger.log('error', 'Plugin failed to load', {
-        message: this.loadError.message,
-        stack: this.loadError.stack.split('\n'),
-      })
+      this.logger.error('Plugin failed to load', this.loadError)
       return false
     }
     const respondsTo = this.script.respondsTo(input)
@@ -55,7 +52,7 @@ class RootScript extends InputBlock {
         })
       }))
     }).catch((error) => {
-      this.logger.log('error', 'Script failed', { query, error })
+      this.logger.error('Script failed', { query, error })
     })
   }
 }

--- a/app/blocks/output/userScript.js
+++ b/app/blocks/output/userScript.js
@@ -22,10 +22,7 @@ class UserScript extends Block {
 
   call (state, env = {}) {
     if (!this.script) {
-      this.logger.log('error', 'Plugin failed to load', {
-        message: this.loadError.message,
-        stack: this.loadError.stack.split('\n'),
-      })
+      this.logger.error('Plugin failed to load', this.loadError)
       return Promise.resolve()
     }
     this.logger.log('verbose', 'Executing Script', { value: state.value })
@@ -34,7 +31,7 @@ class UserScript extends Block {
       this.logger.log('info', 'User Script results', { value: state.value })
       return state.next()
     }).catch((error) => {
-      this.logger.log('error', 'User Script failed', { value: state.value, error })
+      this.logger.error('User Script failed', { value: state.value, error })
     })
   }
 }

--- a/app/lib/configuration.js
+++ b/app/lib/configuration.js
@@ -41,10 +41,7 @@ class Configuration {
       this.loaded = true
     } catch (e) {
       const logger = require('./logger')
-      logger.log('error', 'Attempted to load an invalid ~/.zazurc.json file', {
-        message: e.message,
-        stack: e.stack,
-      })
+      logger.error('Attempted to load an invalid ~/.zazurc.json file', e)
     }
 
     return this.loaded

--- a/app/lib/logger.js
+++ b/app/lib/logger.js
@@ -1,6 +1,7 @@
 const RotateTransport = require('winston-daily-rotate-file')
 const winston = require('winston')
 const jetpack = require('fs-jetpack')
+const util = require('util')
 
 const configuration = require('./configuration')
 const env = require('./env')
@@ -33,19 +34,14 @@ logger.bindMeta = (data) => {
       logger.log(type, message, mergedOptions)
     },
     error: (message, error) => {
-      logger.log('error', message, {
-        message: error.message,
-        stack: error.stack,
-      })
+      const mergedOptions = Object.assign({}, data, { error: util.inspect(error) })
+      logger.log('error', message, mergedOptions)
     },
   }
 }
 
 logger.error = (message, error) => {
-  logger.log('error', message, {
-    message: error.message,
-    stack: error.stack,
-  })
+  logger.log('error', message, { error: util.inspect(error) })
 }
 
 module.exports = logger


### PR DESCRIPTION
As mentioned in https://github.com/tinytacoteam/zazu-clipboard/pull/16/files#r100716158, the exception of plugins service script block will not be printed on the log.

`{"error":{},"plugin":"tinytacoteam/zazu-clipboard","block":"Monitor","level":"error","message":"Script failed","timestamp":"2017-02-13T06:14:58.813Z"}`

By explicitly using `util.inspect()` to parse the `error`, it will make sure the entire error message will be printed in the log when there is an exception.

`{"error":"{ error: \n   Error: Exception: intentionally error.\n       at resolve (/Users/taowang/.zazu/plugins/tinytacoteam/zazu-clipboard/src/monitor.js:68:13)\n       at nrWrapper (/Users/taowang/lab/node.js/zazu/app/lib/track/newrelic.js:4:14809)\n       at Promise.r (/Users/taowang/lab/node.js/zazu/app/lib/track/newrelic.js:4:6024)\n       at ServiceScript.start [as script] (/Users/taowang/.zazu/plugins/tinytacoteam/zazu-clipboard/src/monitor.js:67:25)\n       at ServiceScript.handle (/Users/taowang/lab/node.js/zazu/app/blocks/external/serviceScript.js:48:37)\n       at /Users/taowang/lab/node.js/zazu/app/blocks/external/serviceScript.js:36:19\n       at nrWrapper (/Users/taowang/lab/node.js/zazu/app/lib/track/newrelic.js:4:14809) }","plugin":"tinytacoteam/zazu-clipboard","block":"Monitor","level":"error","message":"Script failed","timestamp":"2017-02-13T06:14:58.854Z"}`

Signed-off-by: Tao Wang <twang2218@gmail.com>
