### PR TITLE
Add a preview block type.

### DIFF
--- a/app/app.html
+++ b/app/app.html
@@ -38,9 +38,9 @@
       )
 
       // Catch `esc` or `enter` to avoid alert beep.
-      document.body.onkeydown = (e) => {
+      document.addEventListener('keydown', (e) => {
         return e.key !== 'Enter' && e.key !== 'Escape'
-      }
+      })
     </script>
   </body>
 </html>

--- a/app/blocks/output.js
+++ b/app/blocks/output.js
@@ -5,6 +5,7 @@ const UserScript = require('./output/userScript')
 const ShowFile = require('./output/showFile')
 const OpenFile = require('./output/openFile')
 const ReloadConfig = require('./output/reloadConfig')
+const Preview = require('./output/preview')
 
 module.exports = {
   CopyToClipboard,
@@ -14,4 +15,5 @@ module.exports = {
   OpenFile,
   ShowFile,
   ReloadConfig,
+  Preview,
 }

--- a/app/blocks/output/preview.js
+++ b/app/blocks/output/preview.js
@@ -1,0 +1,51 @@
+const Block = require('../block')
+const Template = require('../../lib/template')
+const { windowHelper } = require('../../helpers/window')
+const path = require('path')
+const Screens = require('../../lib/screens')
+
+class Preview extends Block {
+  constructor (data) {
+    super(data)
+    this.message = data.message || '{value}'
+    this.screens = new Screens({
+      windowWidth: 700,
+    })
+  }
+
+  call (state, env = {}) {
+    const win = windowHelper('preview-block', {
+      show: false,
+      width: 700,
+      height: 500,
+      frame: false,
+      resizable: false,
+      autoResize: true,
+      alwaysOnTop: true,
+      skipTaskbar: true,
+      title: 'Large Type',
+      url: path.join('file://', path.dirname(path.dirname(__dirname)), '/preview.html'),
+    })
+    const position = this.screens.getCenterPositionOnCurrentScreen()
+    if (position) {
+      win.setPosition(position.x, position.y)
+    }
+    win.webContents.on('did-finish-load', () => {
+      win.webContents.send('message', Template.compile(this.message, {
+        value: String(state.value),
+      }))
+    })
+    return new Promise((resolve) => {
+      win.on('blur', () => {
+        win.close()
+      })
+      win.on('close', () => {
+        resolve()
+      })
+    }).then(() => {
+      return state.next()
+    })
+  }
+}
+
+module.exports = Preview

--- a/app/helpers/window.js
+++ b/app/helpers/window.js
@@ -1,4 +1,5 @@
-const { BrowserWindow } = require('electron')
+const electron = require('electron')
+const { BrowserWindow } = process.type === 'renderer' ? electron.remote : electron
 
 const autoResize = (dynamicWindow) => {
   const defaultSize = {
@@ -16,7 +17,7 @@ const autoResize = (dynamicWindow) => {
 
   dynamicWindow.webContents.on('did-finish-load', () => {
     const updateHeight = () => {
-      if (!dynamicWindow || !dynamicWindow.isVisible()) { return }
+      if (!dynamicWindow) { return }
       dynamicWindow.webContents.executeJavaScript('document.body.children[0].offsetHeight', (mainContentHeight) => {
         resize(mainContentHeight)
       })

--- a/app/preview.html
+++ b/app/preview.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Zazu</title>
+    <style>
+      body {
+        border-radius: 5px;
+        background-color: rgba(0, 0, 0, 0.9);
+        margin: 0;
+        padding: 0;
+        color: rgba(255, 255, 255, 0.7);
+      }
+      #resize {
+        box-sizing: border-box;
+        max-width: 700px;
+        max-height: 500px;
+        font-size: 150px;
+        padding: 10px;
+        text-align: center;
+      }
+      p {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="resize"></div>
+    <script>
+      const autoSizeText = () => {
+        const el = document.getElementById('resize')
+        const resizeText = () => {
+          const currentSize = parseInt((el.style.fontSize || '150px').slice(0, -2), 10)
+          const elNewFontSize = (currentSize - 1) + 'px'
+          el.style.fontSize = elNewFontSize
+        }
+        while (el.scrollHeight > el.offsetHeight) resizeText()
+      }
+
+      const electron = require('electron')
+      const currentWindow = electron.remote.getCurrentWindow()
+      document.addEventListener('keydown', () => {
+        currentWindow.close()
+      })
+      document.addEventListener('click', () => {
+        currentWindow.close()
+      })
+      electron.ipcRenderer.on('message', (_, message) => {
+        document.getElementById('resize').innerText = message
+        autoSizeText()
+        currentWindow.show()
+      })
+    </script>
+  </body>
+</html>

--- a/docs/_documentation/blocks.md
+++ b/docs/_documentation/blocks.md
@@ -22,8 +22,7 @@ otherwise.
 
 All blocks can have the following properties:
 
-* `id` *mixed*: Unique identifier of the block, used for logging and
-  connections.
+* `id` *mixed*: Unique identifier of the block, used for logging and connections.
 * `connections` *mixed[]*: Blocks to execute if one of the results are chosen.
 * `type` *string*: Name of the block you wish to use.
 
@@ -345,6 +344,20 @@ Give the user a notification with a title and a message.
   "message": "{value}"
 }]
 ~~~~
+
+### Preview
+
+You can display large text in a preview window.
+
+* `message` *string*: Message to display in the window.
+
+~~~ json
+[{
+  "id": "Display",
+  "type": "Preview",
+  "message": "{value}"
+}]
+~~~
 
 ### Open File
 


### PR DESCRIPTION
Fixes #76

I created the [blainesch/zazu-say](https://github.com/blainesch/zazu-say) plugin to test this block type. Just type in "say hello world" and the message "hello world" will be previewed.

This was named `Preview` to be generic enough to possibly be extended to also display images in the future.

![good-day-sir](https://cloud.githubusercontent.com/assets/769039/23140059/5c53c046-f764-11e6-8344-87b9d129c9ba.png)

![foobar](https://cloud.githubusercontent.com/assets/769039/23140166/f8dd51e8-f764-11e6-8145-05d89485accf.png)
