### PR TITLE
Traverse History

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,6 @@ module.exports = {
         },
     },
     "globals": {
-        "Mousetrap": true,
         "newrelic": true,
         "__nr_require": true,
     },

--- a/app/components/results.js
+++ b/app/components/results.js
@@ -1,5 +1,5 @@
 const React = require('react')
-const Mousetrap = require('mousetrap')
+const keyboard = require('../lib/keyboard')
 
 const Result = require('./result')
 const IFrame = require('./iframe')
@@ -42,23 +42,23 @@ const Results = React.createClass({
   },
 
   componentDidMount () {
-    Mousetrap.bind(['ctrl+p', 'ctrl+k', 'up'], () => {
+    keyboard.bind('results', ['ctrl+p', 'ctrl+k', 'up'], () => {
       this.moveUp()
     })
-    Mousetrap.bind(['ctrl+n', 'ctrl+j', 'down'], () => {
+    keyboard.bind('results', ['ctrl+n', 'ctrl+j', 'down'], () => {
       this.moveDown()
     })
-    Mousetrap.bind('enter', () => {
+    keyboard.bind('results', 'enter', () => {
       const { values, handleResultClick, activeIndex } = this.props
       handleResultClick(values[activeIndex])
     })
-    Mousetrap.bind('esc', () => {
+    keyboard.bind('results', 'esc', () => {
       globalEmitter.emit('hideWindow')
     })
   },
 
   componentWillUnmount () {
-    Mousetrap.reset()
+    keyboard.reset('results')
   },
 
   renderPreviewFrame () {

--- a/app/components/search.js
+++ b/app/components/search.js
@@ -1,4 +1,7 @@
 const React = require('react')
+const globalEmitter = require('../lib/globalEmitter')
+const keyboard = require('../lib/keyboard')
+const mergeUnique = require('../lib/mergeUnique')
 
 const Search = React.createClass({
   propTypes: {
@@ -9,6 +12,7 @@ const Search = React.createClass({
   getInitialState () {
     return {
       input: null,
+      history: [],
     }
   },
 
@@ -16,8 +20,45 @@ const Search = React.createClass({
     this.state.input && this.state.input.focus()
   },
 
+  handleSaveQuery () {
+    if (!this.props.value) return
+    const haystack = mergeUnique(this.props.value, this.state.history)
+    this.setState({
+      historyId: -1,
+      history: haystack.slice(0, 10),
+    })
+  },
+
+  handlePreviousSearch () {
+    const historyId = this.state.historyId + 1
+    this.props.handleQueryChange(this.state.history[historyId])
+    this.setState({
+      historyId,
+    })
+  },
+
+  handleNextSearch () {
+    const historyId = this.state.historyId - 1
+    this.props.handleQueryChange(this.state.history[historyId])
+    this.setState({
+      historyId,
+    })
+  },
+
   componentDidMount () {
+    globalEmitter.on('hideWindow', this.handleSaveQuery)
+    keyboard.bind('search', 'ctrl+h', () => {
+      this.handlePreviousSearch()
+    })
+    keyboard.bind('search', 'ctrl+l', () => {
+      this.handleNextSearch()
+    })
     this.focus()
+  },
+
+  componentWillUnmount () {
+    globalEmitter.removeListener('hideWindow', this.handleSaveQuery)
+    keyboard.reset('search')
   },
 
   componentDidUpdate () {
@@ -29,6 +70,9 @@ const Search = React.createClass({
   handleQueryChange (event) {
     const query = event.target.value
     this.props.handleQueryChange(query)
+    this.setState({
+      historyId: -1,
+    })
   },
 
   setReference (input) {
@@ -47,7 +91,7 @@ const Search = React.createClass({
         ref={this.setReference}
         type='text'
         onChange={this.handleQueryChange}
-        value={value}/>
+        value={value} />
     )
   },
 })

--- a/app/components/search.js
+++ b/app/components/search.js
@@ -47,10 +47,10 @@ const Search = React.createClass({
 
   componentDidMount () {
     globalEmitter.on('hideWindow', this.handleSaveQuery)
-    keyboard.bind('search', 'ctrl+h', () => {
+    keyboard.bind('search', 'ctrl+,', () => {
       this.handlePreviousSearch()
     })
-    keyboard.bind('search', 'ctrl+l', () => {
+    keyboard.bind('search', 'ctrl+.', () => {
       this.handleNextSearch()
     })
     this.focus()

--- a/app/lib/keyboard.js
+++ b/app/lib/keyboard.js
@@ -1,0 +1,34 @@
+const Mousetrap = require('mousetrap')
+
+const events = {}
+const self = {
+  emit: (key) => {
+    if (!events[key]) return
+    events[key].forEach((obj) => obj['cb']())
+  },
+
+  unbind: (namespace) => {
+    Object.keys(events).forEach((key) => {
+      events[key].forEach((el, i) => {
+        if (el.namespace === namespace) {
+          events[key].splice(i, 1)
+        }
+      })
+    })
+  },
+
+  bind: (namespace, keys, cb) => {
+    const keysArray = typeof keys === 'string' ? [keys] : keys
+    keysArray.forEach((key) => {
+      if (!events[key]) {
+        events[key] = []
+        Mousetrap.bind(key, () => {
+          self.emit(key)
+        })
+      }
+      events[key].push({cb, namespace})
+    })
+  },
+}
+
+module.exports = self

--- a/app/lib/mergeUnique.js
+++ b/app/lib/mergeUnique.js
@@ -1,0 +1,11 @@
+module.exports = (needle, list) => {
+  const haystack = list.slice(0)
+  if (haystack.includes(needle)) {
+    const index = haystack.indexOf(needle)
+    haystack.splice(index, 1)
+  }
+  return [
+    needle,
+    ...haystack,
+  ]
+}

--- a/features/step_definitions/myStepDefinitions.js
+++ b/features/step_definitions/myStepDefinitions.js
@@ -68,8 +68,15 @@ class World {
     return Promise.resolve(this.hitHotkey('space', 'shift'))
   }
 
+  hideWindow () {
+    return Promise.resolve(this.hitHotkey('space', 'shift'))
+  }
+
   hitHotkey (key, modifier) {
-    return Promise.resolve(robot.keyTap(key, modifier))
+    if (modifier) {
+      return Promise.resolve(robot.keyTap(key, modifier))
+    }
+    return Promise.resolve(robot.keyTap(key))
   }
 
   close () {
@@ -164,6 +171,10 @@ module.exports = function () {
     return this.showWindow()
   })
 
+  this.When(/^I toggle it closed$/, function () {
+    return this.hideWindow()
+  })
+
   // assumes modifier is first
   this.When(/^I hit the hotkey "([^"]*)"$/, function (hotkey) {
     var keys = hotkey.split('+')
@@ -202,6 +213,18 @@ module.exports = function () {
     return eventually(() => {
       return this.getResultItems().then((items) => items.length)
     }, parseInt(expected, 10))
+  })
+
+  this.Then(/^the input is empty$/, function () {
+    return eventually(() => {
+      return this.getQuery()
+    }, '')
+  })
+
+  this.Then(/^the input is "([^"]*)"$/, function (expected) {
+    return eventually(() => {
+      return this.getQuery()
+    }, expected)
   })
 
   this.When(/^I type in "([^"]*)"$/, function (input) {

--- a/features/traverse_history.feature
+++ b/features/traverse_history.feature
@@ -25,8 +25,8 @@ Feature: Traverse History
     And I type in "food team"
     And I toggle it closed
     And I toggle it open
-    And I hit the hotkey "control+h"
-    And I hit the hotkey "control+h"
+    And I hit the hotkey "control+,"
+    And I hit the hotkey "control+,"
     Then the input is "food taco"
 
   Scenario: Scroll down
@@ -42,9 +42,9 @@ Feature: Traverse History
     And I type in "food team"
     And I toggle it closed
     And I toggle it open
-    And I hit the hotkey "control+h"
-    And I hit the hotkey "control+h"
-    And I hit the hotkey "control+h"
-    And I hit the hotkey "control+l"
-    And I hit the hotkey "control+l"
+    And I hit the hotkey "control+,"
+    And I hit the hotkey "control+,"
+    And I hit the hotkey "control+,"
+    And I hit the hotkey "control+."
+    And I hit the hotkey "control+."
     Then the input is "food team"

--- a/features/traverse_history.feature
+++ b/features/traverse_history.feature
@@ -1,0 +1,50 @@
+Feature: Traverse History
+  As a user of Zazu
+  I want to be able to scroll through previous searches
+  So I can do the remembering
+
+  Scenario: Clears result when it closes
+    Given I have "tinytacoteam/zazu-fixture" as a plugin
+    And the app is launched
+    When I toggle it open
+    And I type in "food taco"
+    And I toggle it closed
+    And I toggle it open
+    Then the input is empty
+
+  Scenario: Scroll up
+    Given I have "tinytacoteam/zazu-fixture" as a plugin
+    And the app is launched
+    When I toggle it open
+    And I type in "food tiny"
+    And I toggle it closed
+    And I toggle it open
+    And I type in "food taco"
+    And I toggle it closed
+    And I toggle it open
+    And I type in "food team"
+    And I toggle it closed
+    And I toggle it open
+    And I hit the hotkey "control+h"
+    And I hit the hotkey "control+h"
+    Then the input is "food taco"
+
+  Scenario: Scroll down
+    Given I have "tinytacoteam/zazu-fixture" as a plugin
+    And the app is launched
+    When I toggle it open
+    And I type in "food tiny"
+    And I toggle it closed
+    And I toggle it open
+    And I type in "food taco"
+    And I toggle it closed
+    And I toggle it open
+    And I type in "food team"
+    And I toggle it closed
+    And I toggle it open
+    And I hit the hotkey "control+h"
+    And I hit the hotkey "control+h"
+    And I hit the hotkey "control+h"
+    And I hit the hotkey "control+l"
+    And I hit the hotkey "control+l"
+    Then the input is "food team"

--- a/test/app/lib/mergeUnique.spec.js
+++ b/test/app/lib/mergeUnique.spec.js
@@ -1,0 +1,19 @@
+const { expect } = require('chai')
+const mergeUnique = require('../../../app/lib/mergeUnique')
+
+describe('mergeUnique', () => {
+  it('adds to the end', () => {
+    const expected = ['tiny', 'taco', 'team']
+    expect(mergeUnique('tiny', ['taco', 'team'])).to.deep.equal(expected)
+  })
+
+  it('does not add the same item twice', () => {
+    const expected = ['tiny', 'taco', 'team']
+    expect(mergeUnique('tiny', ['tiny', 'taco', 'team'])).to.deep.equal(expected)
+  })
+
+  it('moves items to the beginning', () => {
+    const expected = ['taco', 'tiny', 'team']
+    expect(mergeUnique('taco', ['tiny', 'taco', 'team'])).to.deep.equal(expected)
+  })
+})


### PR DESCRIPTION
`ctrl+,` and `ctrl+.` will move backward and forward through history.  Attempted to use `ctrl+h` and `ctrl+l` however `ctrl+h` deletes input to the left of the cursor.