### PR TITLE
Update Debugger to only display selected plugin

### DIFF
--- a/app/components/debug.js
+++ b/app/components/debug.js
@@ -49,6 +49,11 @@ const Debug = React.createClass({
     })
   },
 
+  allowedPlugins () {
+    if (this.state.selectedPlugin === 'Any') return this.state.plugins
+    else return [this.state.selectedPlugin]
+  },
+
   allowedLevels () {
     if (this.state.selectedLevel === 'error') {
       return ['error']
@@ -62,6 +67,7 @@ const Debug = React.createClass({
   },
 
   render () {
+    const allowedPlugins = this.allowedPlugins()
     const allowedLevels = this.allowedLevels()
 
     return (
@@ -83,7 +89,7 @@ const Debug = React.createClass({
 
         <ul>
           {this.state.items.filter((item) => {
-            return allowedLevels.indexOf(item.level) !== -1
+            return allowedPlugins.indexOf(item.plugin) !== -1 && allowedLevels.indexOf(item.level) !== -1
           }).slice(0, 100).map((item, key) => {
             return (
               <li key={key}>


### PR DESCRIPTION
This change tells the Plugin Debugger to display log entries for only the selected plugin. If the selected plugin is 'Any,' then all plugins are eligible for display. This was a very small code change, but it will really help with my plugin development.

(This is my first ever GitHub pull request, so that's kind of exciting)