### PR TITLE
Run service first, then wait for the given interval

### DIFF
--- a/app/blocks/external/serviceScript.js
+++ b/app/blocks/external/serviceScript.js
@@ -29,9 +29,7 @@ class ServiceScript extends ExternalBlock {
   }
 
   start () {
-    return new Promise((resolve) => {
-      setTimeout(resolve, this.interval)
-    }).then(() => this.handle())
+    return this.handle()
   }
 
   handle () {
@@ -40,10 +38,13 @@ class ServiceScript extends ExternalBlock {
       return Promise.resolve()
     }
     return this._ensurePromise(this.script(this.options))
-    .then(() => this.start())
-    .catch((error) => {
-      this.logger.error('Script failed', error)
-    })
+      .then(() => new Promise((resolve) => {
+        setTimeout(resolve, this.interval)
+      }))
+      .then(() => this.start())
+      .catch((error) => {
+        this.logger.error('Script failed', error)
+      })
   }
 }
 


### PR DESCRIPTION
Change the serviceScript behavior from wait-then-run to run-then-wait.

For long interval, such as several hours, the wait-then-run style will cause a significant delay for running the service, change it to run-then-wait style will let the service run ASAP.

Signed-off-by: Tao Wang <twang2218@gmail.com>