### PR TITLE
Replace setInterval by two calls

### DIFF
--- a/app/lib/notification.js
+++ b/app/lib/notification.js
@@ -3,13 +3,13 @@ const notifier = require('node-notifier')
 class Notification {
   constructor () {
     this.active = false
-    this.interval = setInterval(this.tick.bind(this), 100)
     this.queue = []
   }
 
   push (data) {
     return new Promise((resolve) => {
       this.queue.push(this._notification(data, resolve))
+      this.displayFirstNotificationInQueue()
     })
   }
 
@@ -20,11 +20,12 @@ class Notification {
       this.active = true
       notifier.notify(options, () => {
         this.active = false
+        this.displayFirstNotificationInQueue()
       })
     }
   }
 
-  tick () {
+  displayFirstNotificationInQueue () {
     if (!this.active && this.queue.length > 0) {
       this.queue.shift()()
     }

--- a/test/app/lib/notification.spec.js
+++ b/test/app/lib/notification.spec.js
@@ -3,14 +3,14 @@ const notification = require('../../../app/lib/notification')
 const sinon = require('sinon')
 
 describe('Notification', () => {
-  describe('tick', () => {
+  describe('displayFirstNotificationInQueue', () => {
     let noop
 
     beforeEach(() => {
       noop = sinon.stub()
       notification.queue.push(noop)
       expect(notification.queue.length).to.eq(1)
-      notification.tick()
+      notification.displayFirstNotificationInQueue()
     })
 
     it('shifts the queue', () => {


### PR DESCRIPTION
- Renamed tick() to displayFirstNotificationInQueue() as its not called by
  setInterval anymore
- When we push a new notification, we know there is at least one
notification, so call displayFirstNotificationInQueue right away
- As soon as we set active to false, there is an opportunity to drain
  the queue by calling displayFirstNotificationInQueue

This avoid waking up the zazu process every 100ms when there is nothing
to do and zazu is idle in the backgroud (see issue #271).