### PR TITLE
Initialize screen library when window shows.

### DIFF
--- a/app/lib/screens.js
+++ b/app/lib/screens.js
@@ -18,12 +18,14 @@ class PrimaryScreens {
 class DetectScreens {
   constructor ({ windowWidth }) {
     this.windowWidth = windowWidth
-    this.positions = {}
-    this.screenModule = electron.screen
-    this.monitorDisplays()
+    this.initialized = false
   }
 
   monitorDisplays () {
+    if (this.initialized) return
+    this.initialized = true
+    this.positions = {}
+    this.screenModule = electron.screen
     this.screenModule.on('display-added', () => {
       this.positions = {}
     })
@@ -69,6 +71,7 @@ class DetectScreens {
   }
 
   getCenterPositionOnCurrentScreen () {
+    this.monitorDisplays()
     const currentScreen = this.getCurrentScreen()
     const position = this.positions[currentScreen.id] || {}
     if (position.customPosition) {


### PR DESCRIPTION
This is a possible fix for #280

The issue is that we are loading `electron.screen` before the `app.on('ready')` event, which does not make sense since the stack trace goes back to that exact event. To solve this, I just moved the initialization to when the app shows, which should happen a while after the `ready` event.

@unpeudetout can you take a look at this and see if this resolves the issue?