### PR TITLE
Update package description to reflect Zeal support

### DIFF
--- a/docs/_packages/dash.md
+++ b/docs/_packages/dash.md
@@ -4,5 +4,5 @@ type:        plugin
 title:       "Dash"
 image:       /images/package-icons/dash.png
 githuburl:   fracturedloop/zazu-dash
-description: "Search Dash with Zazu"
+description: "Search Dash or Zeal with Zazu"
 ---


### PR DESCRIPTION
I've tested my zazu-dash plugin with Zeal, and am changing the description to reflect that.