### PR TITLE
Added toggle for hiding the tray item

### DIFF
--- a/app/background.js
+++ b/app/background.js
@@ -10,7 +10,7 @@ const logger = require('./lib/logger')
 const { windowHelper, openCount } = require('./helpers/window')
 const forceSingleInstance = require('./helpers/singleInstance')
 const addToStartup = require('./helpers/startup')
-const createMenu = require('./helpers/menu')
+const { createMenu } = require('./helpers/menu')
 const about = require('./about')
 
 globalEmitter.on('showDebug', (message) => {

--- a/app/background.js
+++ b/app/background.js
@@ -34,6 +34,8 @@ globalEmitter.on('reloadConfig', (message) => {
   app.exit()
 })
 
+globalEmitter.on('quit', () => app.quit())
+
 app.on('ready', function () {
   if (!configuration.load()) {
     return dialog.showMessageBox({

--- a/app/components/search.js
+++ b/app/components/search.js
@@ -1,9 +1,28 @@
 const React = require('react')
 const PropTypes = require('prop-types')
+const { remote } = require('electron')
+const { Menu } = remote
 
+const configuration = require('../lib/configuration')
 const globalEmitter = require('../lib/globalEmitter')
 const keyboard = require('../lib/keyboard')
 const mergeUnique = require('../lib/mergeUnique')
+const { menuTemplate } = require('../helpers/menu')
+const Style = require('./style')
+
+const menu = Menu.buildFromTemplate(menuTemplate)
+
+const css = `
+  .menu-toggle {
+    position: absolute;
+    top: 3px;
+    right: 4px;
+    padding: 0;
+    background: transparent;
+    border: none;
+    color: #545454;
+  }
+`
 
 class Search extends React.Component {
   constructor (props) {
@@ -98,17 +117,29 @@ class Search extends React.Component {
     })
   }
 
+  openMenu = () => {
+    menu.popup()
+  }
+
+  renderMenuToggle = () => (
+    <button onClick={this.openMenu} className='menu-toggle fa fa-cog' />
+  )
+
   render () {
     const { value } = this.props
 
     return (
-      <input
-        title='Search Zazu'
-        className='mousetrap'
-        ref={this.setReference}
-        type='text'
-        onChange={this.handleQueryChange}
-        value={value} />
+      <div>
+        <input
+          title='Search Zazu'
+          className='mousetrap'
+          ref={this.setReference}
+          type='text'
+          onChange={this.handleQueryChange}
+          value={value} />
+        {configuration.hideTrayItem ? this.renderMenuToggle() : null}
+        <Style css={css} />
+      </div>
     )
   }
 }

--- a/app/components/search.js
+++ b/app/components/search.js
@@ -13,7 +13,10 @@ const Style = require('./style')
 const menu = Menu.buildFromTemplate(menuTemplate)
 
 const css = `
-  .menu-toggle {
+  .searchInputWrapper {
+    position: relative;
+  }
+  .menuToggle {
     position: absolute;
     bottom: 3px;
     right: 4px;
@@ -22,7 +25,7 @@ const css = `
     border: none;
     color: #545454;
   }
-  .menu-toggle::before {
+  .menuToggle::before {
     cursor: pointer;
   }
 `
@@ -125,14 +128,14 @@ class Search extends React.Component {
   }
 
   renderMenuToggle = () => (
-    <button onClick={this.openMenu} className='menu-toggle fa fa-cog' />
+    <button onClick={this.openMenu} className='menuToggle fa fa-cog' />
   )
 
   render () {
     const { value } = this.props
 
     return (
-      <div>
+      <div className="searchInputWrapper">
         <input
           title='Search Zazu'
           className='mousetrap'

--- a/app/components/search.js
+++ b/app/components/search.js
@@ -15,12 +15,15 @@ const menu = Menu.buildFromTemplate(menuTemplate)
 const css = `
   .menu-toggle {
     position: absolute;
-    top: 3px;
+    bottom: 3px;
     right: 4px;
     padding: 0;
     background: transparent;
     border: none;
     color: #545454;
+  }
+  .menu-toggle::before {
+    cursor: pointer;
   }
 `
 

--- a/app/helpers/menu.js
+++ b/app/helpers/menu.js
@@ -106,10 +106,13 @@ const trayTemplate = [
     label: 'Quit',
     accelerator: 'CmdOrCtrl+Q',
     click: () => {
-      app.quit()
+      globalEmitter.emit('quit')
     },
   },
 ]
+
+// Remove "Toggle Zazu" for the exposed menu template
+const menuTemplate = trayTemplate.slice(2)
 
 let tray
 module.exports = {
@@ -123,5 +126,5 @@ module.exports = {
     }
     Menu.setApplicationMenu(Menu.buildFromTemplate(appTemplate))
   },
-  menuTemplate: trayTemplate,
+  menuTemplate,
 }

--- a/app/helpers/menu.js
+++ b/app/helpers/menu.js
@@ -1,6 +1,7 @@
 const { app, BrowserWindow, dialog, Menu, Tray } = require('electron')
 const path = require('path')
 
+const configuration = require('../lib/configuration')
 const globalEmitter = require('../lib/globalEmitter')
 const Update = require('../lib/update')
 
@@ -111,11 +112,16 @@ const trayTemplate = [
 ]
 
 let tray
-module.exports = () => {
-  if (app.dock) app.dock.hide()
-  const iconPath = path.join(app.getAppPath(), 'assets', 'images', 'iconTemplate.png')
-  tray = new Tray(iconPath)
-  tray.setToolTip('Toggle Zazu')
-  tray.setContextMenu(Menu.buildFromTemplate(trayTemplate))
-  Menu.setApplicationMenu(Menu.buildFromTemplate(appTemplate))
+module.exports = {
+  createMenu: () => {
+    if (app.dock) app.dock.hide()
+    if (!configuration.hideTrayItem) {
+      const iconPath = path.join(app.getAppPath(), 'assets', 'images', 'iconTemplate.png')
+      tray = new Tray(iconPath)
+      tray.setToolTip('Toggle Zazu')
+      tray.setContextMenu(Menu.buildFromTemplate(trayTemplate))
+    }
+    Menu.setApplicationMenu(Menu.buildFromTemplate(appTemplate))
+  },
+  menuTemplate: trayTemplate,
 }

--- a/app/lib/configuration.js
+++ b/app/lib/configuration.js
@@ -20,6 +20,7 @@ class Configuration {
     this.theme = ''
     this.hotkey = ''
     this.debug = false
+    this.hideTrayItem = false
   }
 
   load () {
@@ -38,6 +39,7 @@ class Configuration {
       this.displayOn = data.displayOn !== 'primary' ? 'detect' : 'primary'
       this.disableAnalytics = data.disableAnalytics
       this.debug = data.debug
+      this.hideTrayItem = data.hideTrayItem
       this.loaded = true
     } catch (e) {
       const logger = require('./logger')

--- a/docs/_documentation/configuration.md
+++ b/docs/_documentation/configuration.md
@@ -101,3 +101,8 @@ configuration.
 If you want your configuration within your application folder for portability just
 create a `portable` directory inside of it. You can copy your configuration files over
 from your home directory if they already exist.
+
+## Hide Tray Item
+
+The tray item can be hidden by setting `hideTrayItem` to `true` in your configuration.
+When hidden, the menu will instead be accessible via a small cog on the search bar.


### PR DESCRIPTION
Config option: `hideTrayItem` (defaults to false)

When hidden, the menu is accessible from a cog on the bottom right of the search bar.

Related to #131 